### PR TITLE
Use env model and limit diff tokens

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ log = { version = "0.4.8", features = ["std"] }
 tokio = { version = "1.28.2", features = ["full"] }
 clap = { version = "4.0.18", features = ["derive"] }
 async-openai = { version = "0.12.0", default-features = false, features = ["native-tls"] }
+
+[lib]
+name = "auto_commit"
+path = "src/lib.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,4 +28,57 @@ mod tests {
         assert_eq!(get_model_from_env(), "custom-model");
         std::env::remove_var("AUTO_COMMIT_MODEL");
     }
+
+    #[test]
+    fn test_truncate_to_n_tokens_zero_limit() {
+        let text = "a b c d e";
+        assert_eq!(truncate_to_n_tokens(text, 0), "");
+    }
+
+    #[test]
+    fn test_truncate_to_n_tokens_empty_string() {
+        let text = "";
+        assert_eq!(truncate_to_n_tokens(text, 5), "");
+    }
+
+    #[test]
+    fn test_truncate_to_n_tokens_limit_exceeds_tokens() {
+        let text = "hello world";
+        assert_eq!(truncate_to_n_tokens(text, 5), "hello world");
+    }
+
+    #[test]
+    fn test_truncate_to_n_tokens_whitespace_normalization() {
+        let text = " a   b  c ";
+        assert_eq!(truncate_to_n_tokens(text, 2), "a b");
+    }
+
+    #[test]
+    fn test_truncate_to_n_tokens_unicode_characters() {
+        let text = "你好 世界 Rust 编程";
+        assert_eq!(truncate_to_n_tokens(text, 3), "你好 世界 Rust");
+    }
+
+    #[test]
+    fn test_get_model_from_env_empty_string() {
+        std::env::set_var("AUTO_COMMIT_MODEL", "");
+        assert_eq!(get_model_from_env(), "");
+        std::env::remove_var("AUTO_COMMIT_MODEL");
+    }
+
+    #[test]
+    fn test_get_model_from_env_whitespace_value() {
+        let custom = "   ";
+        std::env::set_var("AUTO_COMMIT_MODEL", custom);
+        assert_eq!(get_model_from_env(), custom);
+        std::env::remove_var("AUTO_COMMIT_MODEL");
+    }
+
+    #[test]
+    fn test_get_model_from_env_unicode_value() {
+        let custom = "模型一";
+        std::env::set_var("AUTO_COMMIT_MODEL", custom);
+        assert_eq!(get_model_from_env(), custom);
+        std::env::remove_var("AUTO_COMMIT_MODEL");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,31 @@
+pub fn truncate_to_n_tokens(text: &str, limit: usize) -> String {
+    text.split_whitespace().take(limit).collect::<Vec<_>>().join(" ")
+}
+
+pub fn get_model_from_env() -> String {
+    std::env::var("AUTO_COMMIT_MODEL").unwrap_or_else(|_| "gpt-4.1-nano".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_truncate_to_n_tokens() {
+        let text = "a b c d e";
+        assert_eq!(truncate_to_n_tokens(text, 3), "a b c");
+    }
+
+    #[test]
+    fn test_get_model_from_env_default() {
+        std::env::remove_var("AUTO_COMMIT_MODEL");
+        assert_eq!(get_model_from_env(), "gpt-4.1-nano");
+    }
+
+    #[test]
+    fn test_get_model_from_env_custom() {
+        std::env::set_var("AUTO_COMMIT_MODEL", "custom-model");
+        assert_eq!(get_model_from_env(), "custom-model");
+        std::env::remove_var("AUTO_COMMIT_MODEL");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,7 @@ async fn main() -> Result<(), ()> {
 
     let diff_output = Command::new("git")
         .arg("diff")
-        .arg("HEAD")
+        .arg("--staged")
         .output()
         .expect("Couldn't find diff.")
         .stdout;

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ async fn main() -> Result<(), ()> {
     let files_output = Command::new("git")
         .arg("diff")
         .arg("--name-only")
-        .arg("HEAD")
+        .arg("--staged")
         .output()
         .expect("Couldn't get changed files.")
         .stdout;

--- a/src/main.rs
+++ b/src/main.rs
@@ -332,14 +332,15 @@ mod tests {
 
     #[test]
     fn get_model_from_env_returns_env_value_when_set() {
-        std::env::set_var("OPENAI_MODEL", "test-model");
+        std::env::set_var("AUTO_COMMIT_MODEL", "test-model");
         let model = get_model_from_env();
         assert_eq!(model, "test-model".to_string());
+        std::env::remove_var("AUTO_COMMIT_MODEL");
     }
 
     #[test]
     fn get_model_from_env_returns_non_empty_default_when_unset() {
-        std::env::remove_var("OPENAI_MODEL");
+        std::env::remove_var("AUTO_COMMIT_MODEL");
         let model = get_model_from_env();
         assert!(!model.is_empty(), "Default model should not be empty");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,8 @@ async fn main() -> Result<(), ()> {
     let diff_output = str::from_utf8(&diff_output).unwrap();
 
     let combined = format!("Changed files:\n{}\n\nDiff:\n{}", files_changed, diff_output);
-    let output = truncate_to_n_tokens(&combined, 20_000);
+    const MAX_DIFF_TOKENS: usize = 20_000; // Or define elsewhere
+    let output = truncate_to_n_tokens(&combined, MAX_DIFF_TOKENS);
 
     if !cli.dry_run {
         info!("Loading Data...");


### PR DESCRIPTION
## Summary
- add simple tokenizer functions and model loader to new lib crate
- capture changed files and truncate diff to 20k tokens
- read AUTO_COMMIT_MODEL environment variable for model
- add unit tests for new functions

## Testing
- `cargo test --offline` *(fails: no matching package named `async-openai` found)*